### PR TITLE
adding missing return statement in ac_std_float *= operator method

### DIFF
--- a/include/ac_std_float.h
+++ b/include/ac_std_float.h
@@ -1205,6 +1205,7 @@ public:
   }
   ac_std_float &operator *=(const ac_std_float &op2) {
     *this = operator *(op2);
+    return *this;
   }
   ac_std_float &operator /=(const ac_std_float &op2) {
     *this = operator /(op2);


### PR DESCRIPTION
(fiixed error related to 'warning: no return statement in function returning non-void')