### PR TITLE
Add pre-processor error when trying to synthesize mgc_floor

### DIFF
--- a/include/ac_int.h
+++ b/include/ac_int.h
@@ -159,7 +159,9 @@ namespace ac_private {
 #ifndef __SYNTHESIS__
   inline double mgc_floor(double d) { return floor(d); }
 #else
-  inline double mgc_floor(double d) { return 0.0; }
+  inline double mgc_floor(double d) { 
+    #error "mgc_floor on floating point types is not allowed for synthesis" 
+  }
 #endif
 
   #define AC_ASSERT(cond, msg) ac_private::ac_assert(cond, __FILE__, __LINE__, msg)


### PR DESCRIPTION
During synthesis, the calls to mgc_floor are stubbed to return 0.0, which can also be observed in the generated HDL. This change guards against unintended (indirect) uses of the function in code that is supposed to be translated into hardware. A basic test case to validate the change is:

```
#include <ac_int.h>
#include <iostream>

double t(double A[5], double inc) {
  for(int h = 0; h < 5; h++) {
    A[h] =  ac_private::mgc_floor(A[h] + inc);
  }
}

int main()
{   
  double A[5] = {1.2f, 2.3f, 3.4f, 4.5f, 5.6f};
  t(A, 2.1f);
  for(int h = 0; h < 5; h++)
    std::cout << "A[" << h << "] = " << A[h] << std::endl;
  return 0;
}
```

Where the output for simulation can be obtained with:

```
$ g++ -I/usr/local/bin/Mentor_Graphics/Catapult_Synthesis_10.6-912629/Mgc_home/shared/include t.cpp -o test_mgc
$ ./test_mgc 

A[0] = 3
A[1] = 3
A[2] = 3
A[3] = 3
A[4] = 3
```

And the behavior for synthesis (when  __SYNTHESIS__ is defined) is:

```
$ g++ -D__SYNTHESIS__ -I/usr/local/bin/Mentor_Graphics/Catapult_Synthesis_10.6-912629/Mgc_home/shared/include t.cpp -o test_mgc
In file included from t.cpp:331:0:
/usr/local/bin/Mentor_Graphics/Catapult_Synthesis_10.6-912629/Mgc_home/shared/include/ac_int.h:163:6: error: #error "mgc_floor on floating point types is not allowed for synthesis"
     #error "mgc_floor on floating point types is not allowed for synthesis"
      ^~~~~
```

Compilation was performed with g++ 7.5.0